### PR TITLE
Fix warning "‘jump’ may be used uninitialized"

### DIFF
--- a/scripts/sortextable.h
+++ b/scripts/sortextable.h
@@ -101,7 +101,7 @@ do_func(Elf_Ehdr *ehdr, char const *const fname, table_sort_t custom_sort)
 	Elf_Sym *sort_needed_sym;
 	Elf_Shdr *sort_needed_sec;
 	Elf_Rel *relocs = NULL;
-	int relocs_size;
+	int relocs_size = 0;
 	uint32_t *sort_done_location;
 	const char *secstrtab;
 	const char *strtab;


### PR DESCRIPTION
In file included from scripts/sortextable.c:166:0:
scripts/sortextable.c: In function ‘main’:
scripts/sortextable.h:158:3: warning: ‘relocs_size’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   memset(relocs, 0, relocs_size);
   ^
scripts/sortextable.h:104:6: note: ‘relocs_size’ was declared here
  int relocs_size;
      ^
In file included from scripts/sortextable.c:164:0:
scripts/sortextable.h:158:3: warning: ‘relocs_size’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   memset(relocs, 0, relocs_size);
   ^
scripts/sortextable.h:104:6: note: ‘relocs_size’ was declared here
  int relocs_size;
      ^
