### PR TITLE
Enable external module use exported symbols

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -4233,6 +4233,8 @@ int sched_setscheduler_nocheck(struct task_struct *p, int policy,
 	return __sched_setscheduler(p, &attr, false);
 }
 
+EXPORT_SYMBOL(sched_setscheduler_nocheck);
+
 static int
 do_sched_setscheduler(pid_t pid, int policy, struct sched_param __user *param)
 {


### PR DESCRIPTION
Sometimes, an external module uses exported symbols from another external module. kbuild needs to have full knowledge of all symbols to avoid spitting out warnings about undefined symbols.
